### PR TITLE
Add basic instructions for building with docker

### DIFF
--- a/unikraft/Dockerfile
+++ b/unikraft/Dockerfile
@@ -1,0 +1,23 @@
+# Provides the latest kraft binary based on official instructions.
+# SEE: https://unikraft.org/docs/cli/install
+
+FROM debian
+
+RUN apt-get update && \
+  apt-get install -y \
+      ca-certificates \
+      curl \
+      gnupg \
+      lsb-release
+
+RUN mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.pkg.kraftkit.sh/gpg.key | \
+    gpg --dearmor -o /etc/apt/keyrings/unikraft.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/unikraft.gpg] https://deb.pkg.kraftkit.sh /" | \
+  tee /etc/apt/sources.list.d/unikraft.list > /dev/null
+RUN apt-get update && apt-get install -y kraftkit
+
+WORKDIR /mnt/build
+ENTRYPOINT ["kraft"]
+

--- a/unikraft/README.md
+++ b/unikraft/README.md
@@ -14,6 +14,16 @@
 If you just want to test it, this repository contains a pre-built unikernel
 (`example.x86` and `example.arm64`).
 
+## Building with docker
+
+You can build this project with docker by running the following commands:
+```bash
+$ docker build -t kraft .
+$ docker run -it -v "$PWD:/mnt/build" kraft build --plat qemu --arch arm64 
+```
+
+The build results can be found in `.unikraft/build/`.
+
 ## Running
 
 - You can upload it on `hacksat.dev` as an *image*


### PR DESCRIPTION
A convenient and straightforward way to build kraft in a docker environment and use that to build the app.